### PR TITLE
Ripple Effect fixed on main level

### DIFF
--- a/Assets/Scenes/Level.unity
+++ b/Assets/Scenes/Level.unity
@@ -11949,7 +11949,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 154702068}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -839.9777, y: -4.7604976, z: 0}
+  m_LocalPosition: {x: 0, y: -4.25, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -15571,10 +15571,6 @@ PrefabInstance:
     - target: {fileID: 1140863353797431715, guid: 1d2e3d414f446418c84378165ab5fae9, type: 3}
       propertyPath: lookingDuration
       value: 0.6
-      objectReference: {fileID: 0}
-    - target: {fileID: 1140863353797431715, guid: 1d2e3d414f446418c84378165ab5fae9, type: 3}
-      propertyPath: RippleEffectDuration
-      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 1140863353797431715, guid: 1d2e3d414f446418c84378165ab5fae9, type: 3}
       propertyPath: stopDefault.WwiseObjectReference

--- a/Assets/Scenes/Zoi/Ripple.mat
+++ b/Assets/Scenes/Zoi/Ripple.mat
@@ -43,7 +43,7 @@ Material:
     - _opacity: 0.209
     - _ripple_speed: 1
     - _ripple_strenght: 1
-    - _ripplecount: 1
+    - _ripplecount: 0.578
     m_Colors:
     - _Color: {r: 1, g: 1, b: 1, a: 1}
     - _centerripple: {r: 0, g: 0, b: 0, a: 0}

--- a/Assets/Scenes/Zoi/Ripple.shadergraph
+++ b/Assets/Scenes/Zoi/Ripple.shadergraph
@@ -3697,7 +3697,7 @@
     "m_CustomColors": {
         "m_SerializableColors": []
     },
-    "m_Space": 1,
+    "m_Space": 0,
     "m_PositionSource": 0
 }
 


### PR DESCRIPTION
If my changes didn't make it in you just need to adjust RippleEffectDuration for the prefab to .5 for the eye that's has a slow ripple effect.